### PR TITLE
chore: fix field name in handshake option in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Options include:
   handshake: { // if you want to use an handshake performed elsewhere pass it here
     tx,
     rx,
-    handshakeHash,
+    hash,
     publicKey,
     remotePublicKey
   }


### PR DESCRIPTION
The docs currently specify that a `handshakeHash` field exists on the `handshake` option in the constructor, but based on the implementation, this field is called `hash`. This PR updates the docs to reflect that.