### PR TITLE
chore: update readme with note about setKeepAlive

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ the stream is auto destroyed.
 
 #### `s.setKeepAlive(ms)`
 
-Send a heartbeat (empty message) every time the socket is idle for `ms` milliseconds. **Note:** If one side calls `s.setKeepAlive()` and the other does not, then the empty messages will be passed through to the piped stream. These empty messages will cause a stream like [protomux](https://github.com/mafintosh/protomux) to crash.
+Send a heartbeat (empty message) every time the socket is idle for `ms` milliseconds. **Note:** If one side calls `s.setKeepAlive()` and the other does not, then the empty messages will be passed through to the piped stream.
 
 #### `s.publicKey`
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ the stream is auto destroyed.
 
 #### `s.setKeepAlive(ms)`
 
-Send a heartbeat (empty message) every time the socket is idle for `ms` milliseconds.
+Send a heartbeat (empty message) every time the socket is idle for `ms` milliseconds. **Note:** If one side calls `s.setKeepAlive()` and the other does not, then the empty messages will be passed through to the piped stream. These empty messages will cause a stream like [protomux](https://github.com/mafintosh/protomux) to crash.
 
 #### `s.publicKey`
 


### PR DESCRIPTION
Fixes #18 by adding a warning to the README about unexpected behaviour of `setKeepAlive()` which causes empty messages to be passed to the piped stream if only one side of the connection calls `setKeepAlive()`. This can cause crashes in consuming streams, e.g. using [Hypercore](https://github.com/holepunchto/hypercore) if one peer replicates with `core.replicate({ keepAlive: false })` but the other peer replicates with `core.replicate()`, then it will result in a crash in Protomux due to the empty buffer being received.
