### PR TITLE
failing test for end before piped

### DIFF
--- a/test.js
+++ b/test.js
@@ -472,6 +472,22 @@ tape('keep alive', function (t) {
   }
 })
 
+tape('end before piped', function (t) {
+  t.plan(2)
+
+  const a = new NoiseStream(true)
+
+  a.on('finish', function () {
+    t.pass("'finish' event fired")
+  })
+
+  a.on('close', function () {
+    t.pass("'close' event fired")
+  })
+
+  a.end()
+})
+
 function createHandshake () {
   return new Promise((resolve, reject) => {
     const a = new NoiseStream(true)


### PR DESCRIPTION
Calling `s.end()` before the noise stream has been piped to another stream swallows the `finish` and `close` events (see failing test).

I would expect calling `stream.end()` to cause the `finish` and `close` events to be emitted like they do on other streams.