### PR TITLE
Swallow all empty messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ the stream is auto destroyed.
 
 #### `s.setKeepAlive(ms)`
 
-Send a heartbeat (empty message) every time the socket is idle for `ms` milliseconds. **Note:** If one side calls `s.setKeepAlive()` and the other does not, then the empty messages will be passed through to the piped stream.
+Send a heartbeat (empty message) every time the socket is idle for `ms` milliseconds. **Note:** these empty messages are not forwarded to the piped stream.
 
 #### `s.publicKey`
 

--- a/index.js
+++ b/index.js
@@ -319,8 +319,8 @@ module.exports = class NoiseSecretStream extends Duplex {
       return
     }
 
-    // If keep alive is selective, eat the empty buffers (ie assume the other side has it enabled also)
-    if (plain.byteLength === 0 && this._keepAliveMs !== 0) return
+    // All empty messages are swallowed, because it's asumed they're keep-alive messages
+    if (plain.byteLength === 0) return
 
     if (this.push(plain) === false) {
       this.rawStream.pause()


### PR DESCRIPTION
Current behaviour is to only swallow empty messages if your own `keepAlive` is set. This means that if the other side has set `keepAlive` while you haven't, those empty messages will be passed on to the piped stream.

This PR makes it so empty messages are always swallowed.

Note: if anything upstream relies on empty messages for anything other than `keepAlive`, it will break.