### PR TITLE
Expose keepAliveMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Populated after `open` is emitted.
 Get the unique hash of this handshake.
 Populated after `open` is emitted.
 
-#### `s.keepAliveMs`
+#### `s.keepAlive`
 
 Get the interval (in milliseconds) at which keep-alive messages are sent (0 means none are sent).
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Populated after `open` is emitted.
 Get the unique hash of this handshake.
 Populated after `open` is emitted.
 
+#### `s.keepAliveMs`
+
+Get the interval (in milliseconds) at which keep-alive messages are sent (0 means none are sent).
+
 #### `s.on('connect', onconnect)`
 
 Emitted when the handshake is fully done.

--- a/index.js
+++ b/index.js
@@ -78,6 +78,10 @@ module.exports = class NoiseSecretStream extends Duplex {
     return streamId(handshakeHash, isInitiator, id)
   }
 
+  get keepAliveMs () {
+    return this._keepAliveMs
+  }
+
   setTimeout (ms) {
     if (!ms) ms = 0
 

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = class NoiseSecretStream extends Duplex {
     this._timeout = null
     this._timeoutMs = 0
     this._keepAlive = null
-    this._keepAliveMs = 0
+    this.keepAliveMs = 0
 
     if (opts.autoStart !== false) this.start(rawStream, opts)
 
@@ -76,10 +76,6 @@ module.exports = class NoiseSecretStream extends Duplex {
 
   static id (handshakeHash, isInitiator, id) {
     return streamId(handshakeHash, isInitiator, id)
-  }
-
-  get keepAliveMs () {
-    return this._keepAliveMs
   }
 
   setTimeout (ms) {
@@ -97,7 +93,7 @@ module.exports = class NoiseSecretStream extends Duplex {
   setKeepAlive (ms) {
     if (!ms) ms = 0
 
-    this._keepAliveMs = ms
+    this.keepAliveMs = ms
 
     if (!ms || this.rawStream === null) return
 
@@ -128,8 +124,8 @@ module.exports = class NoiseSecretStream extends Duplex {
     if (opts.data) this._onrawdata(opts.data)
     if (opts.ended) this._onrawend()
 
-    if (this._keepAliveMs > 0 && this._keepAlive === null) {
-      this.setKeepAlive(this._keepAliveMs)
+    if (this.keepAliveMs > 0 && this._keepAlive === null) {
+      this.setKeepAlive(this.keepAliveMs)
     }
 
     if (this._timeoutMs > 0 && this._timeout === null) {
@@ -324,7 +320,7 @@ module.exports = class NoiseSecretStream extends Duplex {
     }
 
     // If keep alive is selective, eat the empty buffers (ie assume the other side has it enabled also)
-    if (plain.byteLength === 0 && this._keepAliveMs !== 0) return
+    if (plain.byteLength === 0 && this.keepAliveMs !== 0) return
 
     if (this.push(plain) === false) {
       this.rawStream.pause()
@@ -476,7 +472,7 @@ module.exports = class NoiseSecretStream extends Duplex {
     if (this._keepAlive === null) return
     this._keepAlive.destroy()
     this._keepAlive = null
-    this._keepAliveMs = 0
+    this.keepAliveMs = 0
   }
 
   _destroy (cb) {

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = class NoiseSecretStream extends Duplex {
     this._timeout = null
     this._timeoutMs = 0
     this._keepAlive = null
-    this.keepAliveMs = 0
+    this.keepAlive = 0
 
     if (opts.autoStart !== false) this.start(rawStream, opts)
 
@@ -93,7 +93,7 @@ module.exports = class NoiseSecretStream extends Duplex {
   setKeepAlive (ms) {
     if (!ms) ms = 0
 
-    this.keepAliveMs = ms
+    this.keepAlive = ms
 
     if (!ms || this.rawStream === null) return
 
@@ -124,8 +124,8 @@ module.exports = class NoiseSecretStream extends Duplex {
     if (opts.data) this._onrawdata(opts.data)
     if (opts.ended) this._onrawend()
 
-    if (this.keepAliveMs > 0 && this._keepAlive === null) {
-      this.setKeepAlive(this.keepAliveMs)
+    if (this.keepAlive > 0 && this._keepAlive === null) {
+      this.setKeepAlive(this.keepAlive)
     }
 
     if (this._timeoutMs > 0 && this._timeout === null) {
@@ -320,7 +320,7 @@ module.exports = class NoiseSecretStream extends Duplex {
     }
 
     // If keep alive is selective, eat the empty buffers (ie assume the other side has it enabled also)
-    if (plain.byteLength === 0 && this.keepAliveMs !== 0) return
+    if (plain.byteLength === 0 && this.keepAlive !== 0) return
 
     if (this.push(plain) === false) {
       this.rawStream.pause()
@@ -472,7 +472,7 @@ module.exports = class NoiseSecretStream extends Duplex {
     if (this._keepAlive === null) return
     this._keepAlive.destroy()
     this._keepAlive = null
-    this.keepAliveMs = 0
+    this.keepAlive = 0
   }
 
   _destroy (cb) {

--- a/test.js
+++ b/test.js
@@ -459,7 +459,7 @@ test('keep alive', function (t) {
 
   a.setKeepAlive(500)
   b.setKeepAlive(500)
-  t.is(a.keepAliveMs, 500)
+  t.is(a.keepAlive, 500)
 
   a.resume()
 

--- a/test.js
+++ b/test.js
@@ -450,7 +450,7 @@ test('can timeout', function (t) {
 })
 
 test('keep alive', function (t) {
-  t.plan(1)
+  t.plan(2)
 
   const a = new NoiseStream(true)
   const b = new NoiseStream(false)
@@ -459,6 +459,7 @@ test('keep alive', function (t) {
 
   a.setKeepAlive(500)
   b.setKeepAlive(500)
+  t.is(a.keepAliveMs, 500)
 
   a.resume()
 


### PR DESCRIPTION
Context: I couldn't see an obvious reason to keep that info internal-only, and it helps with testing the upcoming hyperdht `connectionKeepAlive`option