### PR TITLE
Bugfix keep alive

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,12 +98,11 @@ module.exports = class NoiseSecretStream extends Duplex {
   }
 
   setKeepAlive (ms) {
-    if (this._keepAliveTimer) {
-      if (this.keepAlive === ms) return
-      this._clearKeepAlive()
-    }
-
     if (!ms) ms = 0
+
+    if (this.keepAlive === ms) return
+
+    this._clearKeepAlive()
 
     this.keepAlive = ms
 

--- a/index.js
+++ b/index.js
@@ -98,6 +98,11 @@ module.exports = class NoiseSecretStream extends Duplex {
   }
 
   setKeepAlive (ms) {
+    if (this._keepAliveTimer) {
+      if (this.keepAlive === ms) return
+      this._clearKeepAlive()
+    }
+
     if (!ms) ms = 0
 
     this.keepAlive = ms

--- a/test.js
+++ b/test.js
@@ -483,6 +483,62 @@ test('keep alive', function (t) {
   }
 })
 
+test('set keep alive multiple times (no mem leak)', function (t) {
+  t.plan(4)
+
+  const a = new NoiseStream(true)
+  const b = new NoiseStream(false)
+
+  let i = 0
+
+  a.setKeepAlive(500)
+  b.setKeepAlive(500)
+  t.is(a.keepAlive, 500, 'sanity check')
+
+  // Needs access to internals to test for fixed memleak
+  const initTimer = a._keepAliveTimer
+
+  a.setKeepAlive(600)
+  t.is(a.keepAlive, 600)
+  t.is(initTimer.done, true, 'prev timer destroyed')
+  a.resume()
+
+  const interval = setInterval(tick, 100)
+
+  a.rawStream.pipe(b.rawStream).pipe(a.rawStream)
+  b.rawStream.on('data', function (data) {
+    if (data.byteLength === 20) { // empty message
+      clearInterval(interval)
+      t.ok(i > 10, 'keep alive when idle')
+      a.end()
+      b.end()
+    }
+  })
+
+  function tick () {
+    i++
+    if (i < 10) {
+      b.write('hi')
+    }
+  }
+})
+
+test('setting keep alive to same value does nothing', function (t) {
+  const a = new NoiseStream(true)
+
+  a.setKeepAlive(500)
+  t.is(a.keepAlive, 500, 'sanity check')
+
+  // Needs access to internals to test
+  const initTimer = a._keepAliveTimer
+
+  a.setKeepAlive(500)
+  t.is(initTimer === a._keepAliveTimer, true, 'not replaced')
+
+  a.setKeepAlive(600)
+  t.is(initTimer === a._keepAliveTimer, false, 'replaced (sanity check')
+})
+
 test('message is too large', function (t) {
   t.plan(2)
 


### PR DESCRIPTION
Current behaviour causes a memleak when setKeepAlive is called multiple times (it retains the stream forever).

Needed for hyperdht 6.16.0 due to https://github.com/holepunchto/hyperdht/commit/8d27b7eaf81ffd55f5fcc7492926c1d3e30a7647, which combined with Hypercore replication causes setKeepAlive to be called twice 