### PR TITLE
Bugfix: setKeepAlive called before start race condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,8 +100,6 @@ module.exports = class NoiseSecretStream extends Duplex {
   setKeepAlive (ms) {
     if (!ms) ms = 0
 
-    if (this.keepAlive === ms) return
-
     this._clearKeepAlive()
 
     this.keepAlive = ms


### PR DESCRIPTION
Previous fix introduced a race condition: https://github.com/holepunchto/hyperswarm-secret-stream/pull/35

(the keep-alive timer doesn't get set when the rawStream doesn't exist yet. setKeepAlive gets called again during start, but the special-case on the same keepAlive value early returned then. The easy fix is just to get rid of the special case, as it's a tiny optimisation)