### PR TITLE
Encrypted UDP messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ Emitted when the handshake is fully done.
 It is safe to write to the stream immediately though, as data is buffered
 internally before the handshake has been completed.
 
+#### `await s.send(buffer)`
+Sends an encrypted unordered message, see [udx-native](https://github.com/holepunchto/udx-native/tree/main?tab=readme-ov-file#await-streamsendbuffer) for details.  
+This method with silently fail if the underlying rawStream is not an UDX-stream.
+
+#### `s.trySend(buffer)`
+Same as `send(buffer)` but does not return a promise.
+
+#### `s.on('message', onmessage)`
+Emmitted when an unordered message is received
+
 #### `keyPair = SecretStream.keyPair([seed])`
 
 Generate a ed25519 key pair.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ internally before the handshake has been completed.
 
 #### `await s.send(buffer)`
 Sends an encrypted unordered message, see [udx-native](https://github.com/holepunchto/udx-native/tree/main?tab=readme-ov-file#await-streamsendbuffer) for details.  
-This method with silently fail if the underlying rawStream is not an UDX-stream.
+This method with silently fail if called before handshake is complete or if the underlying rawStream is not an UDX-stream (not capable of UDP).
 
 #### `s.trySend(buffer)`
 Same as `send(buffer)` but does not return a promise.

--- a/index.js
+++ b/index.js
@@ -526,7 +526,9 @@ module.exports = class NoiseSecretStream extends Duplex {
 
     const prefix = this._boxSeq.subarray(0, 8)
     sodium.sodium_increment(prefix)
-    if (b4a.equals(prefix, this._boxSeq.subarray(8))) throw new Error('nonce exhausted')
+    if (b4a.equals(prefix, this._boxSeq.subarray(8))) {
+      this.destroy(new Error('udp send nonce exchausted'))
+    }
 
     const secret = this._boxSecret.subarray(0, 32)
     const envelope = b4a.allocUnsafe(8 + MB + buffer.length)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "devDependencies": {
     "brittle": "^3.3.0",
-    "standard": "^17.1.0"
+    "standard": "^17.1.0",
+    "udx-native": "^1.13.2"
   },
   "scripts": {
     "test": "standard && brittle test.js"

--- a/test.js
+++ b/test.js
@@ -657,7 +657,8 @@ test('encrypted unordered message', async function (t) {
 
   const transmission1 = new Promise(resolve => b.once('message', resolve))
 
-  await new Promise(resolve => a.once('connect', resolve))
+  await a.opened
+  await b.opened
 
   await a.send(message)
 

--- a/test.js
+++ b/test.js
@@ -686,21 +686,3 @@ test('encrypted unordered message', async function (t) {
 
   await destroy()
 })
-
-test.skip('message fragmentation', async t => {
-  const [a, b, destroy] = udxPair()
-  const burstMTU = Buffer.allocUnsafe(6000) // UDP MTU ~1500 bytes
-
-  const transmission = new Promise(resolve => b.once('message', resolve))
-
-  await a.opened
-  await b.opened
-
-  await a.send(burstMTU)
-  console.log('big buffer sent')
-
-  const received = await transmission
-  t.ok(received.equals(burstMTU), 'fragmentation works')
-
-  await destroy()
-})


### PR DESCRIPTION
In order to send private unordered messages (live-streams or updates / UDP-style)

I've lifted udx-stream's `await send(buffer)`, `trySend(buffer)` and `on('message', onmessage)` API
as an encrypted variant.

I'm not sure about:
- `_onmessage(buffer)` when handshake is pending, the buffer is pushed onto the eventqueue. Do I need to copy the message to free/detach it from udx's receive buffers?
- in `send` and `trySend` what happens if buffer exceeds MTU?
- in `_onmessage(buffer)` and `_boxMessage(buffer)` when handshake is awaited, what happens if handshake fails?