### PR TITLE
Bugfix: ignore too-short messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Options include:
     hash,
     publicKey,
     remotePublicKey
-  }
+  },
+  setupOnMessage: true // (advanced) set false to not set up an onmessage handler
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Options include:
     publicKey,
     remotePublicKey
   },
-  setupOnMessage: true // (advanced) set false to not set up an onmessage handler
+  enableSend: true // (advanced) set false to disable the send API
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -568,6 +568,8 @@ module.exports = class NoiseSecretStream extends Duplex {
     const MB = sodium.crypto_secretbox_MACBYTES // 16
     const NB = sodium.crypto_secretbox_NONCEBYTES // 24
 
+    if (buffer.byteLength < NB) return // Invalid message
+
     const nonce = b4a.allocUnsafe(NB)
     b4a.fill(nonce, 0)
     nonce.set(buffer.subarray(0, 8))
@@ -575,6 +577,8 @@ module.exports = class NoiseSecretStream extends Duplex {
     const secret = this._sendState.subarray(32, 64)
     const ciphertext = buffer.subarray(8)
     const plain = buffer.subarray(8, buffer.byteLength - MB)
+
+    if (ciphertext.byteLength < MB) return // invalid message
 
     const success = sodium.crypto_secretbox_open_easy(plain, ciphertext, nonce, secret)
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = class NoiseSecretStream extends Duplex {
     this.connected = false
     this.keepAlive = opts.keepAlive || 0
     this.timeout = 0
-    this.setupOnMessage = opts.setupOnMessage !== false
+    this.enableSend = opts.enableSend !== false
 
     // pointer for upstream to set data here if they want
     this.userData = null
@@ -422,7 +422,7 @@ module.exports = class NoiseSecretStream extends Duplex {
     this._rawStream.on('end', this._onrawend.bind(this))
     this._rawStream.on('drain', this._onrawdrain.bind(this))
 
-    if (this.setupOnMessage) this._rawStream.on('message', this._onmessage.bind(this))
+    if (this.enableSend) this._rawStream.on('message', this._onmessage.bind(this))
 
     if (this._encrypt !== null) {
       this._resolveOpened(true)

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = class NoiseSecretStream extends Duplex {
     this.connected = false
     this.keepAlive = opts.keepAlive || 0
     this.timeout = 0
+    this.setupOnMessage = opts.setupOnMessage !== false
 
     // pointer for upstream to set data here if they want
     this.userData = null
@@ -420,7 +421,8 @@ module.exports = class NoiseSecretStream extends Duplex {
     this._rawStream.on('data', this._onrawdata.bind(this))
     this._rawStream.on('end', this._onrawend.bind(this))
     this._rawStream.on('drain', this._onrawdrain.bind(this))
-    this._rawStream.on('message', this._onmessage.bind(this))
+
+    if (this.setupOnMessage) this._rawStream.on('message', this._onmessage.bind(this))
 
     if (this._encrypt !== null) {
       this._resolveOpened(true)

--- a/test.js
+++ b/test.js
@@ -716,7 +716,7 @@ test('too short messages are ignored', async function (t) {
   await destroy()
 })
 
-test('setupOnMessage opt', async function (t) {
+test('enableSend opt', async function (t) {
   t.plan(1)
 
   const u = new UDX()
@@ -729,7 +729,7 @@ test('setupOnMessage opt', async function (t) {
   stream1.connect(socket1, stream2.id, socket2.address().port, '127.0.0.1')
   stream2.connect(socket2, stream1.id, socket1.address().port, '127.0.0.1')
 
-  const a = new NoiseStream(true, stream1, { setupOnMessage: false })
+  const a = new NoiseStream(true, stream1, { enableSend: false })
   const b = new NoiseStream(false, stream2)
 
   a.once('message', () => t.fail('should not have registered message handler'))


### PR DESCRIPTION
Previous behaviour was to throw an error (sodium throws when its parameters have an incorrect length).

Alternative solution: try-catch the sodium.crypto_secretbox_open_easy call, but that seems overly general